### PR TITLE
Add Gulp automation for local development and Firebase deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,4 @@ functions/package-lock.json
 *.cache
 .DS_Store
 postmarkConfig.json
-public/.DS_Store
+dist/.DS_Store

--- a/firebase.json
+++ b/firebase.json
@@ -13,7 +13,7 @@
     }
   ],
   "hosting": {
-    "public": "public",
+    "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,61 @@
+const { src, dest, series, parallel, watch } = require('gulp');
+const htmlmin = require('gulp-htmlmin');
+const cleanCSS = require('gulp-clean-css');
+const terser = require('gulp-terser');
+const imagemin = require('gulp-imagemin');
+const del = require('del');
+const browserSync = require('browser-sync').create();
+const { spawn } = require('child_process');
+
+function clean() {
+  return del(['dist']);
+}
+
+function html() {
+  return src('dev/**/*.html')
+    .pipe(htmlmin({ collapseWhitespace: true }))
+    .pipe(dest('dist'));
+}
+
+function styles() {
+  return src('dev/**/*.css')
+    .pipe(cleanCSS())
+    .pipe(dest('dist'));
+}
+
+function scripts() {
+  return src('dev/**/*.js')
+    .pipe(terser())
+    .pipe(dest('dist'));
+}
+
+function images() {
+  return src('dev/**/*.{png,jpg,jpeg,gif,svg,ico}')
+    .pipe(imagemin())
+    .pipe(dest('dist'));
+}
+
+function fonts() {
+  return src('dev/**/*.{eot,svg,ttf,woff,woff2}')
+    .pipe(dest('dist'));
+}
+
+function serve() {
+  browserSync.init({
+    server: { baseDir: 'dev' }
+  });
+
+  watch('dev/**/*').on('change', browserSync.reload);
+}
+
+function firebaseDeploy(done) {
+  const cmd = spawn('firebase', ['deploy', '--only', 'hosting'], { stdio: 'inherit' });
+  cmd.on('close', done);
+}
+
+const build = series(clean, parallel(html, styles, scripts, images, fonts));
+
+exports.clean = clean;
+exports.build = build;
+exports.deploy = series(build, firebaseDeploy);
+exports.local = serve;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "uptime",
+  "version": "1.0.0",
+  "description": "This repository contains the source code and documentation for the Uptime Monitoring System to be deployed at Ronald Reagan Washington National Airport and Washington Dulles International Airport. The system monitors the uptime of elevators, escalators, and moving walkways (EEMWs) and sends notifications when any device experiences downtime. This helps ensure operational efficiency and safety within airport facilities, particularly in high-traffic areas.",
+  "main": "index.js",
+  "scripts": {
+    "deploy": "gulp deploy",
+    "local": "gulp local",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "browser-sync": "^2.29.3",
+    "del": "^6.1.1",
+    "gulp": "^4.0.2",
+    "gulp-clean-css": "^4.3.0",
+    "gulp-htmlmin": "^5.0.1",
+    "gulp-imagemin": "^7.1.0",
+    "gulp-terser": "^2.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with gulp-based deploy and local scripts
- create gulpfile with tasks to build assets, serve locally, and deploy to Firebase
- point Firebase hosting config to the dist build output

## Testing
- `npm test`
- `npm install` (fails: 403 Forbidden from registry)


------
https://chatgpt.com/codex/tasks/task_e_6890bfa6ce44832b84a7d43213cb2ce9