### PR TITLE
Remove campus parameter from uptime paths and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ This project utilizes a variety of Software as a Service (SaaS) products to ensu
 |------------|---------|-----------------------------------------------------------------------------|----------|
 | deviceID   | String  | Unique identifier for the device (e.g., "Escalator01").                      | Yes      |
 | type       | String  | Type of the device; must be one of the following: `escalator`, `elevator`, or `movingsidewalk`. | Yes      |
-| campus     | String  | Identifier for the campus; must be either `IAD` or `DCA`.                   | Yes      |
 | power      | Boolean | The current power status of the device; `true` for powered, `false` for offline.  | Yes      |
 | alarm      | Boolean | The current alarm status of the device; `true` for no alarm, `false` for alarm triggered. | Yes      |
 | apikey      | String | API key | Yes      |
@@ -190,7 +189,6 @@ curl --location 'https://us-central1-uptime-eb91e.cloudfunctions.net/updateUptim
 --data '{
   "deviceID": "Escalator01",
   "type": "escalator",
-  "campus": "IAD",
   "power": true,
   "alarm": true,
   "apikey": "XXX"

--- a/hardware/Sensor Code/Uptime_device_tripple.ino
+++ b/hardware/Sensor Code/Uptime_device_tripple.ino
@@ -8,9 +8,6 @@ const char* password = "Mwaa1987!";
 // API endpoint
 const char* apiURL = "https://us-central1-uptime-eb91e.cloudfunctions.net/updateUptime";
 
-// Device configuration
-const char* campus = "DCA";  // Options: "DCA" or "IAD"
-
 // Unit 1 configuration
 const char* deviceID1 = "Sidewalk01";  // Unique ID for each ESP32
 const char* type1 = "sidewalk";  // Options: "elevator", "escalator", "sidewalk"
@@ -169,7 +166,6 @@ void sendStatus(const char* deviceID, const char* type, bool powerState, bool al
 
     String payload = "{";
     payload += "\"deviceID\":\"" + String(deviceID) + "\",";
-    payload += "\"campus\":\"" + String(campus) + "\",";
     payload += "\"type\":\"" + String(type) + "\",";
     payload += "\"power\":" + String(powerState ? "true" : "false") + ",";
     payload += "\"alarm\":" + String(alarmState ? "true" : "false");

--- a/website/index.html
+++ b/website/index.html
@@ -62,14 +62,6 @@
         class="container-fluid d-flex justify-content-between align-items-center"
       >
         <a class="navbar-brand" href="#">Uptime Monitor</a>
-        <ul class="navbar-nav flex-row">
-          <li class="nav-item">
-            <a class="nav-link" href="#" id="dca-tab">DCA</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#" id="iad-tab">IAD</a>
-          </li>
-        </ul>
         <span class="navbar-text">
           This application is not supported by the Office of Technology.
         </span>


### PR DESCRIPTION
## Summary
- Simplify updateUptime Cloud Function to ignore `campus` and store records at `/devices/{type}/{deviceID}`
- Drop campus selector on dashboard and read devices directly from root `/devices`
- Update example sensor code and documentation to match new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ca4da0fc832ba0a065d0c8cd8ae3