### PR TITLE
Remove outage log feature

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -19,43 +19,6 @@
       <div id="deviceAccordion" class="accordion container-fluid"></div>
     </div>
 
-    <!-- Outage Log Modal -->
-    <div
-      class="modal fade"
-      id="outageLogModal"
-      tabindex="-1"
-      aria-labelledby="outageLogModalLabel"
-      aria-hidden="true"
-    >
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="outageLogModalLabel">
-              Outage Log for <span id="modalDeviceID"></span>
-            </h5>
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-              aria-label="Close"
-            ></button>
-          </div>
-          <div class="modal-body">
-            <ul id="outageLogList" class="list-group"></ul>
-          </div>
-          <div class="modal-footer">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              data-bs-dismiss="modal"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- Fixed Footer Navbar -->
     <nav class="navbar fixed-bottom navbar-dark bg-dark">
       <div

--- a/website/script.js
+++ b/website/script.js
@@ -23,17 +23,6 @@ function loadFirebaseConfig() {
 
 // No campus selection; devices are loaded directly from the root
 
-// Attach click listeners to the device cards for showing outage logs
-const attachCardEventListeners = () => {
-  document.querySelectorAll('.device-card').forEach((card) => {
-    card.addEventListener('click', (event) => {
-      const deviceID = event.currentTarget.getAttribute('data-id');
-      const type = event.currentTarget.getAttribute('data-type');
-      showOutageLogs(deviceID, type);
-    });
-  });
-};
-
 // Load and display devices
 const loadDevices = () => {
   const db = firebase.database();
@@ -241,8 +230,6 @@ const loadDevices = () => {
         }
       }
 
-      // Attach event listeners to the device cards for showing outage logs
-      attachCardEventListeners();
     },
     (error) => {
       console.error('Error loading devices:', error);
@@ -253,60 +240,6 @@ const loadDevices = () => {
   );
 };
 
-// Function to show outage logs in a modal
-const showOutageLogs = (deviceID, type) => {
-  const outageLogList = document.getElementById('outageLogList');
-  const modalDeviceID = document.getElementById('modalDeviceID');
-
-  // Clear previous logs
-  outageLogList.innerHTML = '';
-  modalDeviceID.textContent = deviceID;
-
-  // Reference to the outage logs in Firebase
-  const outageLogsRef = firebase
-    .database()
-    .ref(`/outageLogs/${type}/${deviceID}/outages`)
-    .limitToLast(10);
-  outageLogsRef.once('value', (snapshot) => {
-    const outages = snapshot.val();
-
-    if (outages) {
-      // Iterate over each outage and display the details
-      Object.entries(outages).forEach(([key, outage]) => {
-        const start = new Date(outage.start * 1000).toLocaleString();
-        const end = outage.end
-          ? new Date(outage.end * 1000).toLocaleString()
-          : 'Ongoing';
-        const duration = outage.end
-          ? outage.end - outage.start
-          : Math.floor(Date.now() / 1000) - outage.start;
-        const hours = Math.floor(duration / 3600);
-        const minutes = Math.floor((duration % 3600) / 60);
-        const seconds = duration % 60;
-
-        const listItem = document.createElement('li');
-        listItem.className = 'list-group-item';
-        listItem.innerHTML = `<strong>Start:</strong> ${start} <br>
-                                <strong>End:</strong> ${end} <br>
-                                <strong>Duration:</strong> ${hours}h ${minutes}m ${seconds}s`;
-
-        outageLogList.appendChild(listItem);
-      });
-    } else {
-      // No outages recorded
-      const listItem = document.createElement('li');
-      listItem.className = 'list-group-item';
-      listItem.textContent = 'No recorded outages.';
-      outageLogList.appendChild(listItem);
-    }
-
-    // Show the modal
-    const outageLogModal = new bootstrap.Modal(
-      document.getElementById('outageLogModal')
-    );
-    outageLogModal.show();
-  });
-};
 
 // Function to show Bootstrap alerts
 function showAlert(message, type = 'info') {


### PR DESCRIPTION
## Summary
- remove outage log modal and related script hooks from dashboard
- stop storing outage details and drop unused uptime calculation function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d3964ee8832b9914a29f8c3df41e