### PR TITLE
Add secret API key validation to updateUptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ This project utilizes a variety of Software as a Service (SaaS) products to ensu
 | type       | String  | Type of the device; must be one of the following: `escalator`, `elevator`, or `movingsidewalk`. | Yes      |
 | power      | Boolean | The current power status of the device; `true` for powered, `false` for offline.  | Yes      |
 | alarm      | Boolean | The current alarm status of the device; `true` for no alarm, `false` for alarm triggered. | Yes      |
-| apikey      | String | API key | Yes      |
+| api_key    | String | API key used to authorize requests; must match the server's secret. | Yes      |
 
 ---
+
+All requests must include a valid `api_key` that matches the `SECRET_API_KEY` configured in Firebase Functions.
 
 #### Example Request
 
@@ -187,11 +189,11 @@ Below is an example of how to send data to the API using `curl`:
 curl --location 'https://us-central1-uptime-eb91e.cloudfunctions.net/updateUptime' \
 --header 'Content-Type: application/json' \
 --data '{
+  "api_key": "XXX",
   "deviceID": "Escalator01",
   "type": "escalator",
   "power": true,
-  "alarm": true,
-  "apikey": "XXX"
+  "alarm": true
 }'
 ```
 

--- a/hardware/Sensor Code/Uptime_device_tripple.ino
+++ b/hardware/Sensor Code/Uptime_device_tripple.ino
@@ -8,6 +8,9 @@ const char* password = "Mwaa1987!";
 // API endpoint
 const char* apiURL = "https://us-central1-uptime-eb91e.cloudfunctions.net/updateUptime";
 
+// API key for authentication
+const char* apiKey = "YOUR_API_KEY";
+
 // Unit 1 configuration
 const char* deviceID1 = "Sidewalk01";  // Unique ID for each ESP32
 const char* type1 = "sidewalk";  // Options: "elevator", "escalator", "sidewalk"
@@ -165,6 +168,7 @@ void sendStatus(const char* deviceID, const char* type, bool powerState, bool al
     http.addHeader("Content-Type", "application/json");
 
     String payload = "{";
+    payload += "\"api_key\":\"" + String(apiKey) + "\",";
     payload += "\"deviceID\":\"" + String(deviceID) + "\",";
     payload += "\"type\":\"" + String(type) + "\",";
     payload += "\"power\":" + String(powerState ? "true" : "false") + ",";


### PR DESCRIPTION
## Summary
- require matching `api_key` for `updateUptime` requests
- document `api_key` usage and update sample hardware payload

## Testing
- `npm test`
- `cd API && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6890e8a8f2d4832b9566a8fceafa8a3e