### PR TITLE
feat: add device name support

### DIFF
--- a/API/updateUptime.js
+++ b/API/updateUptime.js
@@ -63,7 +63,7 @@ const updateUptime = functions
       return res.status(405).send('Method Not Allowed');
     }
 
-    const { api_key, deviceID, type, power, alarm } = req.body;
+    const { api_key, deviceID, type, power, alarm, device_name } = req.body;
 
     // Validate API key
     if (!api_key) {
@@ -75,7 +75,14 @@ const updateUptime = functions
     }
 
     // Validate the request body
-    if (!deviceID || !type || typeof power !== 'boolean' || typeof alarm !== 'boolean') {
+    if (
+      !deviceID ||
+      !type ||
+      typeof power !== 'boolean' ||
+      typeof alarm !== 'boolean' ||
+      typeof device_name !== 'string' ||
+      device_name.trim() === ''
+    ) {
       return res.status(400).send('Missing or incorrect required parameters');
     }
 
@@ -91,6 +98,7 @@ const updateUptime = functions
     const now = Math.floor(Date.now() / 1000);
     let updates = {
       last_statuscheck_timestamp: now,
+      device_name,
     };
 
     let triggerEmail = false;
@@ -118,6 +126,7 @@ const updateUptime = functions
         alarm,
         last_statuscheck_timestamp: now,
         lastStatusChangeTimestamp: now,
+        device_name,
       };
 
       // If the device is offline during its first entry, prepare to send an email

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This project utilizes a variety of Software as a Service (SaaS) products to ensu
 | Parameter  | Type    | Description                                                                 | Required |
 |------------|---------|-----------------------------------------------------------------------------|----------|
 | deviceID   | String  | Unique identifier for the device (e.g., "Escalator01").                      | Yes      |
+| device_name| String  | Human-readable name for the device (e.g., "East Wing Escalator 1").          | Yes      |
 | type       | String  | Type of the device; must be one of the following: `escalator`, `elevator`, or `movingsidewalk`. | Yes      |
 | power      | Boolean | The current power status of the device; `true` for powered, `false` for offline.  | Yes      |
 | alarm      | Boolean | The current alarm status of the device; `true` for no alarm, `false` for alarm triggered. | Yes      |
@@ -191,6 +192,7 @@ curl --location 'https://us-central1-uptime-eb91e.cloudfunctions.net/updateUptim
 --data '{
   "api_key": "XXX",
   "deviceID": "Escalator01",
+  "device_name": "East Wing Escalator 1",
   "type": "escalator",
   "power": true,
   "alarm": true

--- a/website/script.js
+++ b/website/script.js
@@ -113,6 +113,7 @@ const loadDevices = () => {
           // Create a card for each device and display its status
           groupedDevices[type].forEach((device) => {
             const deviceID = device.deviceID;
+            const deviceName = device.device_name || deviceID;
             const isMonitored = device.monitored;
             const deviceStatus =
               isMonitored && device.power && !device.alarm
@@ -154,7 +155,7 @@ const loadDevices = () => {
             deviceDiv.innerHTML = `
               <div class="card mb-3 ${deviceStatus === 'online' ? 'border-success' : 'border-danger'}">
                 <div class="card-body">
-                  <h4 class="card-title">${deviceID}</h4>
+                  <h4 class="card-title">${deviceName}</h4>
                   <p class="card-text small text-muted">${
                     device.location || 'Location unknown'
                   }</p>


### PR DESCRIPTION
## Summary
- require `device_name` in updateUptime API and persist to database
- display device name instead of device ID on dashboard
- document new `device_name` parameter in README

## Testing
- `npm test`
- `cd API && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6890eaf11d5c832bbd1d686c026d3e94