### PR TITLE
Handle plural device type keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "deploy": "gulp deploy",
     "local": "gulp local",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/website/index.html
+++ b/website/index.html
@@ -35,6 +35,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.min.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-database.js"></script>
+    <script src="utils.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/website/script.js
+++ b/website/script.js
@@ -55,11 +55,15 @@ const loadDevices = () => {
 
       // Group devices by type
       for (let type in devices) {
-        type = type.toLowerCase(); // Normalize type to lowercase
-        if (!groupedDevices[type]) continue; // Skip if type is not recognized
+        const normalizedType = normalizeDeviceType(type);
+        if (!groupedDevices[normalizedType]) continue; // Skip if type is not recognized
         for (const deviceID in devices[type]) {
           const device = devices[type][deviceID];
-          groupedDevices[type].push({ type, deviceID, ...device });
+          groupedDevices[normalizedType].push({
+            type: normalizedType,
+            deviceID,
+            ...device,
+          });
         }
       }
 

--- a/website/utils.js
+++ b/website/utils.js
@@ -1,0 +1,8 @@
+function normalizeDeviceType(type) {
+  if (!type) return '';
+  return type.toLowerCase().replace(/s$/, '');
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { normalizeDeviceType };
+}

--- a/website/utils.test.js
+++ b/website/utils.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { normalizeDeviceType } = require('./utils.js');
+
+test('normalizeDeviceType removes trailing s from plural forms', () => {
+  assert.strictEqual(normalizeDeviceType('escalators'), 'escalator');
+  assert.strictEqual(normalizeDeviceType('elevators'), 'elevator');
+  assert.strictEqual(normalizeDeviceType('sidewalks'), 'sidewalk');
+});
+
+test('normalizeDeviceType leaves singular forms unchanged', () => {
+  assert.strictEqual(normalizeDeviceType('escalator'), 'escalator');
+  assert.strictEqual(normalizeDeviceType('ELEVATOR'), 'elevator');
+});


### PR DESCRIPTION
## Summary
- Normalize device type names so singular and plural keys are accepted
- Load the normalization helper on the dashboard and apply it when grouping devices
- Add tests for device type normalization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ef972b1c832b928bcaa28a031c56