### PR TITLE
Display correct indicator colors for power and alarms

### DIFF
--- a/website/script.js
+++ b/website/script.js
@@ -118,7 +118,9 @@ const loadDevices = () => {
           groupedDevices[type].forEach((device) => {
             const deviceID = device.deviceID;
             const deviceName = device.device_name || deviceID;
-            const isMonitored = device.monitored;
+            // Treat devices as monitored by default if the field is undefined.
+            const isMonitored =
+              device.monitored !== undefined ? device.monitored : true;
             const deviceStatus =
               isMonitored && device.power && !device.alarm
                 ? 'online'
@@ -165,10 +167,10 @@ const loadDevices = () => {
                   }</p>
                   <p class="card-text">
                     <strong>Power:</strong> <span class="power-indicator" style="color: ${
-                      isMonitored ? (device.power ? 'green' : 'red') : 'grey'
+                      isMonitored ? getPowerColor(device.power) : 'grey'
                     };"><i class="fas fa-circle"></i></span><br>
                     <strong>Alarm:</strong> <span class="alarm-indicator" style="color: ${
-                      isMonitored ? (device.alarm ? 'red' : 'green') : 'grey'
+                      isMonitored ? getAlarmColor(device.alarm) : 'grey'
                     };"><i class="fas fa-circle"></i></span><br>
                     <strong>${timeLabel}:</strong> <span id="timer-${deviceID}">${
               isMonitored ? '' : '-'
@@ -209,8 +211,8 @@ const loadDevices = () => {
                 const alarmIndicator =
                   deviceDiv.querySelector('.alarm-indicator');
 
-                powerIndicator.style.color = device.power ? 'green' : 'red';
-                alarmIndicator.style.color = device.alarm ? 'red' : 'green';
+                powerIndicator.style.color = getPowerColor(device.power);
+                alarmIndicator.style.color = getAlarmColor(device.alarm);
 
                 // Update last sensor reading
                 const lastReadingElement = deviceDiv.querySelector(

--- a/website/utils.js
+++ b/website/utils.js
@@ -3,6 +3,18 @@ function normalizeDeviceType(type) {
   return type.toLowerCase().replace(/s$/, '');
 }
 
+// Map a power status boolean to the corresponding indicator color.
+// `true` indicates the device has power and returns green, otherwise red.
+function getPowerColor(power) {
+  return power ? 'green' : 'red';
+}
+
+// Map an alarm status boolean to the corresponding indicator color.
+// `true` indicates an alarm condition and returns red, otherwise green.
+function getAlarmColor(alarm) {
+  return alarm ? 'red' : 'green';
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { normalizeDeviceType };
+  module.exports = { normalizeDeviceType, getPowerColor, getAlarmColor };
 }

--- a/website/utils.test.js
+++ b/website/utils.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { normalizeDeviceType } = require('./utils.js');
+const { normalizeDeviceType, getPowerColor, getAlarmColor } = require('./utils.js');
 
 test('normalizeDeviceType removes trailing s from plural forms', () => {
   assert.strictEqual(normalizeDeviceType('escalators'), 'escalator');
@@ -12,4 +12,14 @@ test('normalizeDeviceType removes trailing s from plural forms', () => {
 test('normalizeDeviceType leaves singular forms unchanged', () => {
   assert.strictEqual(normalizeDeviceType('escalator'), 'escalator');
   assert.strictEqual(normalizeDeviceType('ELEVATOR'), 'elevator');
+});
+
+test('getPowerColor returns green for true and red for false', () => {
+  assert.strictEqual(getPowerColor(true), 'green');
+  assert.strictEqual(getPowerColor(false), 'red');
+});
+
+test('getAlarmColor returns red for true and green for false', () => {
+  assert.strictEqual(getAlarmColor(true), 'red');
+  assert.strictEqual(getAlarmColor(false), 'green');
 });


### PR DESCRIPTION
## Summary
- Add utility helpers for mapping power and alarm booleans to indicator colors
- Use new helpers in dashboard and treat devices as monitored by default
- Test indicator color helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f1eadafc832b95a947851b4ee204