### PR TITLE
Copy Firebase config before deployment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,11 @@ function fonts() {
     .pipe(dest('dist'));
 }
 
+function firebaseConfig() {
+  return src('website/My_Firebase_Config.json')
+    .pipe(dest('dist'));
+}
+
 function serve() {
   browserSync.init({
     server: { baseDir: 'website' }
@@ -57,5 +62,5 @@ const build = series(clean, parallel(html, styles, scripts, images, fonts));
 
 exports.clean = clean;
 exports.build = build;
-exports.deploy = series(build, firebaseDeploy);
+exports.deploy = series(build, firebaseConfig, firebaseDeploy);
 exports.local = serve;


### PR DESCRIPTION
## Summary
- add gulp task to copy `My_Firebase_Config.json` into `dist`
- ensure deploy sequence copies config before running Firebase hosting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891446706e4832b89393aef4ddba627