### PR TITLE
fix: accurately count online devices

### DIFF
--- a/website/script.js
+++ b/website/script.js
@@ -99,10 +99,8 @@ const loadDevices = () => {
           section.classList.add('mb-8');
           section.setAttribute('data-type', type);
 
-          // Count online devices
-          const onlineCount = groupedDevices[type].filter(
-            (device) => device.monitored && device.power && !device.alarm
-          ).length;
+          // Count online devices. A device is online when it has power and no alarm.
+          const onlineCount = countOnlineDevices(groupedDevices[type]);
           const totalCount = groupedDevices[type].length;
 
           // Section header

--- a/website/utils.js
+++ b/website/utils.js
@@ -15,6 +15,20 @@ function getAlarmColor(alarm) {
   return alarm ? 'red' : 'green';
 }
 
+// Count the number of devices that are online. A device is considered online
+// when `power` is true and `alarm` is false. The `monitored` flag is ignored;
+// devices without a `monitored` property should still be counted if their
+// power and alarm values indicate an online state.
+function countOnlineDevices(devices) {
+  if (!Array.isArray(devices)) return 0;
+  return devices.filter((device) => device && device.power && !device.alarm).length;
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { normalizeDeviceType, getPowerColor, getAlarmColor };
+  module.exports = {
+    normalizeDeviceType,
+    getPowerColor,
+    getAlarmColor,
+    countOnlineDevices,
+  };
 }

--- a/website/utils.test.js
+++ b/website/utils.test.js
@@ -1,7 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { normalizeDeviceType, getPowerColor, getAlarmColor } = require('./utils.js');
+const {
+  normalizeDeviceType,
+  getPowerColor,
+  getAlarmColor,
+  countOnlineDevices,
+} = require('./utils.js');
 
 test('normalizeDeviceType removes trailing s from plural forms', () => {
   assert.strictEqual(normalizeDeviceType('escalators'), 'escalator');
@@ -22,4 +27,14 @@ test('getPowerColor returns green for true and red for false', () => {
 test('getAlarmColor returns red for true and green for false', () => {
   assert.strictEqual(getAlarmColor(true), 'red');
   assert.strictEqual(getAlarmColor(false), 'green');
+});
+
+test('countOnlineDevices counts devices with power true and alarm false', () => {
+  const devices = [
+    { power: true, alarm: false },
+    { power: false, alarm: false },
+    { power: true, alarm: true },
+    { power: true, alarm: false, monitored: false },
+  ];
+  assert.strictEqual(countOnlineDevices(devices), 2);
 });


### PR DESCRIPTION
## Summary
- count online devices using power and alarm fields only
- use new helper to display correct online counts
- cover counting logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891fe7bb180832b85ef0d389734f201